### PR TITLE
Eliminar botón de editar según la lógica discutida

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -196,9 +196,19 @@ body {
 }
 .item-details {
   flex-grow: 1;
-  cursor: pointer;
   display: flex;
   align-items: center;
+}
+
+.clickable-card {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  border-radius: 0.5rem;
+  padding: 0.25rem;
+}
+
+.clickable-card:hover {
+  background-color: rgba(255, 255, 255, 0.3);
 }
 .list-item:hover {
   transform: scale(1.02);
@@ -283,13 +293,7 @@ input:checked + .slider:before {
 .dish-list-item:hover {
   transform: none;
 }
-.edit-dish-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--gray-text);
-  margin-right: 0.5rem;
-}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -606,13 +610,7 @@ input:checked + .slider:before {
   .dish-list-item:hover {
     transform: none;
   }
-  .edit-dish-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--gray-text);
-    margin-right: 0.5rem;
-  }
+
   .modal-backdrop {
     position: fixed;
     inset: 0;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -210,7 +210,7 @@ async function loadDishes(cardId) {
         const imageUrl = dish.photoUrl || `https://placehold.co/120x120/E2E8F0/4A5568?text=${encodeURIComponent(dish.name.substring(0, 4))}`;
 
         dishElement.innerHTML = `
-    <div class="item-details">
+    <div class="item-details clickable-card" data-dish-id="${dish.id}">
         <img src="${imageUrl}" alt="Foto de ${dish.name}" style="width: 60px; height: 60px; border-radius: 0.5rem; object-fit: cover; margin-right: 1rem;">
         <div>
             <h3>${dish.name}</h3>
@@ -218,18 +218,12 @@ async function loadDishes(cardId) {
             <p style="font-size: 0.85rem; color: #666;">Likes: ${dish.likesCount || 0}</p> 
         </div>
     </div>
-    <button class="edit-dish-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-        </svg>
-    </button>
     <label class="toggle-switch">
         <input type="checkbox" data-id="${dish.id}" class="dish-toggle" ${dish.isActive ? 'checked' : ''}>
         <span class="slider"></span>
     </label>
 `;
-        dishElement.querySelector('.edit-dish-btn').addEventListener('click', () => openEditDishModal(dish));
+        dishElement.querySelector('.clickable-card').addEventListener('click', () => openEditDishModal(dish));
         dishesListDiv.appendChild(dishElement);
       });
 


### PR DESCRIPTION
 📋 Cambios Realizados
 ❌ Eliminación del botón de editar
- Removido el botón-ícono de "Editar" de las tarjetas de platos
- Eliminados todos los estilos CSS relacionados con .edit-dish-btn
- Limpieza del código HTML y JavaScript asociado
 🎯 Tarjeta completamente clickeable
- Implementada funcionalidad para hacer clic en toda la tarjeta del plato
- Agregada clase clickable-card con estilos apropiados
- Añadido efecto hover para indicar interactividad
- Área de clic significativamente más grande y intuitiva
 🔄 Preservación del toggle de visibilidad
- El interruptor de visibilidad mantiene su funcionalidad independiente
- No hay interferencia entre el clic de la tarjeta y el toggle
- Comportamiento original del toggle completamente preservado